### PR TITLE
Release v0.7.0 in place of yanked v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/spiraldb/fastlanes/compare/v0.6.1...v0.7.0) - 2026-08-26
+
+This release has the same contents as 0.6.2. Version 0.6.2 is yanked, because
+it has breaking changes that a patch release must not have:
+
+- The `std` feature is replaced by the `runtime` feature ([#175](https://github.com/spiraldb/fastlanes/pull/175))
+- `Transpose::transpose`/`untranspose` use the same element order as
+  `bit_transpose`/`bit_untranspose` ([#186](https://github.com/spiraldb/fastlanes/pull/186))
+
 ## [0.6.2](https://github.com/spiraldb/fastlanes/compare/v0.6.1...v0.6.2) - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,4 @@
 # Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-## [0.2.2](https://github.com/spiraldb/fastlanes/compare/v0.2.1...v0.2.2) - 2025-09-15
-
-### Other
-
-- use `get_unchecked` for index accesses in rle ([#76](https://github.com/spiraldb/fastlanes/pull/76))
-- improve fls-rle comments ([#75](https://github.com/spiraldb/fastlanes/pull/75))
-- *(deps)* update codspeedhq/action digest to 653fdc3 ([#73](https://github.com/spiraldb/fastlanes/pull/73))
-- *(deps)* pin dependencies ([#67](https://github.com/spiraldb/fastlanes/pull/67))
-- *(deps)* update codspeedhq/action action to v4 ([#69](https://github.com/spiraldb/fastlanes/pull/69))
-- *(deps)* update actions/checkout action to v5 ([#68](https://github.com/spiraldb/fastlanes/pull/68))
-
-## [0.2.1](https://github.com/spiraldb/fastlanes/compare/v0.2.0...v0.2.1) - 2025-09-05
-
-### Added
-
-- fastlanes rle ([#70](https://github.com/spiraldb/fastlanes/pull/70))
-# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -165,6 +140,23 @@ it has breaking changes that a patch release must not have:
 - move all benchmarks to divan ([#83](https://github.com/spiraldb/fastlanes/pull/83))
 - Narrow down the scope of paste macro ([#77](https://github.com/spiraldb/fastlanes/pull/77))
 - *(deps)* update marcoieni/release-plz-action digest to acb9246 ([#74](https://github.com/spiraldb/fastlanes/pull/74))
+
+## [0.2.2](https://github.com/spiraldb/fastlanes/compare/v0.2.1...v0.2.2) - 2025-09-15
+
+### Other
+
+- use `get_unchecked` for index accesses in rle ([#76](https://github.com/spiraldb/fastlanes/pull/76))
+- improve fls-rle comments ([#75](https://github.com/spiraldb/fastlanes/pull/75))
+- *(deps)* update codspeedhq/action digest to 653fdc3 ([#73](https://github.com/spiraldb/fastlanes/pull/73))
+- *(deps)* pin dependencies ([#67](https://github.com/spiraldb/fastlanes/pull/67))
+- *(deps)* update codspeedhq/action action to v4 ([#69](https://github.com/spiraldb/fastlanes/pull/69))
+- *(deps)* update actions/checkout action to v5 ([#68](https://github.com/spiraldb/fastlanes/pull/68))
+
+## [0.2.1](https://github.com/spiraldb/fastlanes/compare/v0.2.0...v0.2.1) - 2025-09-05
+
+### Added
+
+- fastlanes rle ([#70](https://github.com/spiraldb/fastlanes/pull/70))
 
 ## [0.2.0](https://github.com/spiraldb/fastlanes/compare/v0.1.8...v0.2.0) - 2025-07-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "fastlanes"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "arrayref",
  "codspeed-divan-compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastlanes"
-version = "0.6.2"
+version = "0.7.0"
 description = "Rust implementation of the FastLanes compression layout"
 license = "Apache-2.0"
 homepage = "https://github.com/spiraldb/fastlanes"


### PR DESCRIPTION
0.6.2 had fixes that should be also classified as breaks and went out as 0.7.0
