### PR TITLE
feat(bitpacking): Add batched index unpacking

### DIFF
--- a/benches/bitpacking.rs
+++ b/benches/bitpacking.rs
@@ -1,3 +1,4 @@
+use std::mem::MaybeUninit;
 use std::mem::size_of;
 
 use arrayref::{array_mut_ref, array_ref};
@@ -89,6 +90,145 @@ fn unpack_single_16_from_3(bencher: Bencher) {
         }
     });
 }
+
+const MAX_BENCHMARK_INDICES: usize = 128;
+
+#[derive(Clone, Copy)]
+enum IndexDistribution {
+    Uniform,
+    Clustered,
+    UnorderedWithDuplicates,
+}
+
+fn benchmark_indices(
+    distribution: IndexDistribution,
+    num_indices: usize,
+) -> [usize; MAX_BENCHMARK_INDICES] {
+    assert!(num_indices <= MAX_BENCHMARK_INDICES);
+    let mut indices = [0; MAX_BENCHMARK_INDICES];
+
+    match distribution {
+        IndexDistribution::Uniform => {
+            for (position, index) in indices[..num_indices].iter_mut().enumerate() {
+                *index = position * 1024 / num_indices;
+            }
+        }
+        IndexDistribution::Clustered => {
+            for (position, index) in indices[..num_indices].iter_mut().enumerate() {
+                *index = 448 + position;
+            }
+        }
+        IndexDistribution::UnorderedWithDuplicates => {
+            for position in 0..num_indices {
+                indices[position] = if position > 0 && position % 4 == 0 {
+                    indices[position - 1]
+                } else {
+                    (position * 541 + 17) % 1024
+                };
+            }
+        }
+    }
+
+    indices
+}
+
+macro_rules! unpack_indices_benchmarks {
+    ($module:ident, $type:ty, $width:expr, $distribution:expr) => {
+        mod $module {
+            use super::*;
+
+            const WIDTH: usize = $width;
+            const PACKED_LENGTH: usize = 1024 * WIDTH / <$type>::T;
+
+            fn fixture(
+                num_indices: usize,
+            ) -> ([$type; PACKED_LENGTH], [usize; MAX_BENCHMARK_INDICES]) {
+                let mask = ((1_u128 << WIDTH) - 1) as $type;
+                let values =
+                    std::array::from_fn(|index| ((index as $type).wrapping_mul(17)) & mask);
+                let mut packed = [0; PACKED_LENGTH];
+                BitPacking::pack::<WIDTH, PACKED_LENGTH>(&values, &mut packed);
+                let indices = benchmark_indices($distribution, num_indices);
+                (packed, indices)
+            }
+
+            #[divan::bench(args = [1, 8, 32, 128], sample_size = 10_000)]
+            fn batched(bencher: Bencher, num_indices: usize) {
+                let (packed, indices) = fixture(num_indices);
+                let mut output = [MaybeUninit::<$type>::uninit(); MAX_BENCHMARK_INDICES];
+
+                bencher.bench_local(|| {
+                    let packed = black_box(&packed);
+                    let indices = black_box(&indices[..num_indices]);
+                    let output = black_box(&mut output[..num_indices]);
+                    // SAFETY: `packed` contains exactly one packed FastLanes block.
+                    unsafe {
+                        BitPacking::unchecked_unpack_indices(WIDTH, packed, indices, output);
+                    }
+                    black_box(&*output);
+                });
+            }
+
+            #[divan::bench(args = [1, 8, 32, 128], sample_size = 10_000)]
+            fn repeated_single(bencher: Bencher, num_indices: usize) {
+                let (packed, indices) = fixture(num_indices);
+                let mut output = [MaybeUninit::<$type>::uninit(); MAX_BENCHMARK_INDICES];
+
+                bencher.bench_local(|| {
+                    let packed = black_box(&packed);
+                    let indices = black_box(&indices[..num_indices]);
+                    let output = black_box(&mut output[..num_indices]);
+                    for (&index, value) in indices.iter().zip(output.iter_mut()) {
+                        // SAFETY: `packed` contains exactly one packed FastLanes block.
+                        value.write(unsafe {
+                            BitPacking::unchecked_unpack_single(WIDTH, packed, index)
+                        });
+                    }
+                    black_box(&*output);
+                });
+            }
+
+            #[divan::bench(args = [1, 8, 32, 128], sample_size = 10_000)]
+            fn full_unpack_then_gather(bencher: Bencher, num_indices: usize) {
+                let (packed, indices) = fixture(num_indices);
+                let mut unpacked = [0; 1024];
+                let mut output = [MaybeUninit::<$type>::uninit(); MAX_BENCHMARK_INDICES];
+
+                bencher.bench_local(|| {
+                    let packed = black_box(&packed);
+                    let indices = black_box(&indices[..num_indices]);
+                    let unpacked = black_box(&mut unpacked);
+                    let output = black_box(&mut output[..num_indices]);
+                    // SAFETY: both buffers have the required lengths for `WIDTH`.
+                    unsafe { BitPacking::unchecked_unpack(WIDTH, packed, unpacked) };
+                    for (&index, value) in indices.iter().zip(output.iter_mut()) {
+                        value.write(unpacked[index]);
+                    }
+                    black_box(&*output);
+                });
+            }
+        }
+    };
+}
+
+unpack_indices_benchmarks!(
+    unpack_indices_u16_width3_uniform,
+    u16,
+    3,
+    IndexDistribution::Uniform
+);
+unpack_indices_benchmarks!(
+    unpack_indices_u32_width16_clustered,
+    u32,
+    16,
+    IndexDistribution::Clustered
+);
+unpack_indices_benchmarks!(
+    unpack_indices_u64_width63_unordered_duplicates,
+    u64,
+    63,
+    IndexDistribution::UnorderedWithDuplicates
+);
 
 #[divan::bench(sample_count = 10000)]
 fn throughput_compress(bencher: Bencher) {

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -57,16 +57,7 @@ pub trait BitPacking: FastLanes {
         packed: &[Self; B],
         indices: &[usize],
         output: &mut [MaybeUninit<Self>],
-    ) {
-        assert_eq!(
-            indices.len(),
-            output.len(),
-            "Output length must equal index length"
-        );
-        for (&index, value) in indices.iter().zip(output) {
-            value.write(Self::unpack_single::<W, B>(packed, index));
-        }
-    }
+    );
 
     /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements,
     /// where `W` is runtime-known instead of compile-time known.
@@ -101,22 +92,7 @@ pub trait BitPacking: FastLanes {
         input: &[Self],
         indices: &[usize],
         output: &mut [MaybeUninit<Self>],
-    ) {
-        assert!(
-            width <= Self::T,
-            "Width must be less than or equal to {}",
-            Self::T
-        );
-        assert_eq!(
-            indices.len(),
-            output.len(),
-            "Output length must equal index length"
-        );
-        for (&index, value) in indices.iter().zip(output) {
-            // SAFETY: the caller guarantees that `input` contains the packed representation.
-            value.write(unsafe { Self::unchecked_unpack_single(width, input, index) });
-        }
-    }
+    );
 }
 
 macro_rules! impl_packing {
@@ -269,6 +245,22 @@ macro_rules! impl_packing {
                     let hi = packed[<$T>::LANES * (start_word + 1) + lane] << remaining_bits;
                     (lo | hi) & mask
                 };
+            }
+
+            fn unpack_indices<const W: usize, const B: usize>(
+                packed: &[Self; B],
+                indices: &[usize],
+                output: &mut [MaybeUninit<Self>],
+            ) {
+                const {
+                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                    assert!(B == 1024 * W / Self::T);
+                }
+
+                assert_eq!(indices.len(), output.len(), "Output length must equal index length");
+                for (&index, value) in indices.iter().zip(output) {
+                    value.write(Self::unpack_single::<W, B>(packed, index));
+                }
             }
 
             unsafe fn unchecked_unpack_single(width: usize, packed: &[Self], index: usize) -> Self {

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -44,17 +44,6 @@ pub trait BitPacking: FastLanes {
     /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements.
     fn unpack_single<const W: usize, const B: usize>(packed: &[Self; B], index: usize) -> Self;
 
-    /// Unpacks selected elements from a packed array of 1024 `W` bit elements.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the output length differs from the index length or an index is not less than 1024.
-    fn unpack_indices<const W: usize, const B: usize>(
-        packed: &[Self; B],
-        indices: &[usize],
-        output: &mut [MaybeUninit<Self>],
-    );
-
     /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements,
     /// where `W` is runtime-known instead of compile-time known.
     ///
@@ -66,6 +55,17 @@ pub trait BitPacking: FastLanes {
     ///
     /// These lengths are checked only with `debug_assert` (i.e., not checked on release builds).
     unsafe fn unchecked_unpack_single(width: usize, input: &[Self], index: usize) -> Self;
+
+    /// Unpacks selected elements from a packed array of 1024 `W` bit elements.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the output length differs from the index length or an index is not less than 1024.
+    fn unpack_indices<const W: usize, const B: usize>(
+        packed: &[Self; B],
+        indices: &[usize],
+        output: &mut [MaybeUninit<Self>],
+    );
 
     /// Unpacks selected elements where `W` is known only at runtime.
     ///
@@ -149,7 +149,6 @@ macro_rules! impl_packing {
                     assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
                     assert!(B == 1024 * W / Self::T);
                 }
-
 
                 for lane in 0..Self::LANES {
                     unpack!($T, W, input, lane, |$idx, $elem| {
@@ -240,28 +239,6 @@ macro_rules! impl_packing {
                 };
             }
 
-            fn unpack_indices<const W: usize, const B: usize>(
-                packed: &[Self; B],
-                indices: &[usize],
-                output: &mut [MaybeUninit<Self>],
-            ) {
-                const {
-                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
-                    assert!(B == 1024 * W / Self::T);
-                }
-
-                assert_eq!(indices.len(), output.len(), "Output length must equal index length");
-                if W == 0 {
-                    assert!(
-                        indices.iter().all(|&index| index < 1024),
-                        "Index must be less than 1024"
-                    );
-                }
-                for (&index, value) in indices.iter().zip(output) {
-                    value.write(Self::unpack_single::<W, B>(packed, index));
-                }
-            }
-
             unsafe fn unchecked_unpack_single(width: usize, packed: &[Self], index: usize) -> Self {
                 const T: usize = <$T>::T;
 
@@ -286,6 +263,28 @@ macro_rules! impl_packing {
                 }))
             }
 
+            fn unpack_indices<const W: usize, const B: usize>(
+                packed: &[Self; B],
+                indices: &[usize],
+                output: &mut [MaybeUninit<Self>],
+            ) {
+                const {
+                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                    assert!(B == 1024 * W / Self::T);
+                }
+
+                assert_eq!(indices.len(), output.len(), "Output length must equal index length");
+                if W == 0 {
+                    assert!(
+                        indices.iter().all(|&index| index < 1024),
+                        "Index must be less than 1024"
+                    );
+                }
+                for (&index, value) in indices.iter().zip(output) {
+                    value.write(Self::unpack_single::<W, B>(packed, index));
+                }
+            }
+
             unsafe fn unchecked_unpack_indices(
                 width: usize,
                 packed: &[Self],
@@ -294,8 +293,8 @@ macro_rules! impl_packing {
             ) {
                 const T: usize = <$T>::T;
 
-                assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
-                assert_eq!(indices.len(), output.len(), "Output length must equal index length");
+                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+                debug_assert_eq!(indices.len(), output.len(), "Output length must equal index length");
                 let packed_len = 128 * width / size_of::<Self>();
                 debug_assert_eq!(packed.len(), packed_len, "Input buffer must be of size {}", packed_len);
 

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -94,50 +94,6 @@ pub trait BitPacking: FastLanes {
 
 macro_rules! impl_packing {
     ($T:ty) => {
-        paste! {
-            #[inline(always)]
-            fn [<unpack_single_ $T>]<const W: usize, const B: usize>(
-                packed: &[$T; B],
-                index: usize,
-            ) -> $T {
-                const {
-                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
-                    assert!(B == 1024 * W / <$T>::T);
-                }
-
-                if W == 0 {
-                    return 0 as $T;
-                }
-
-                // Packing transposes each logical index into a FastLanes lane and row.
-                // Map the requested index back to those coordinates.
-                assert!(index < 1024, "Index must be less than 1024, got {}", index);
-                let (lane, row): (usize, usize) = {
-                    const LANES: [u8; 1024] = lanes_by_index::<$T>();
-                    const ROWS: [u8; 1024] = rows_by_index::<$T>();
-                    (LANES[index] as usize, ROWS[index] as usize)
-                };
-
-                if W == <$T>::T {
-                    return packed[<$T>::LANES * row + lane];
-                }
-
-                let mask: $T = (1 << (W % <$T>::T)) - 1;
-                let start_bit = row * W;
-                let start_word = start_bit / <$T>::T;
-                let lo_shift = start_bit % <$T>::T;
-                let remaining_bits = <$T>::T - lo_shift;
-
-                let lo = packed[<$T>::LANES * start_word + lane] >> lo_shift;
-                if remaining_bits >= W {
-                    lo & mask
-                } else {
-                    let hi = packed[<$T>::LANES * (start_word + 1) + lane] << remaining_bits;
-                    (lo | hi) & mask
-                }
-            }
-        }
-
         impl BitPacking for $T {
             #[inline(never)]
             fn pack<const W: usize, const B: usize>(
@@ -234,14 +190,47 @@ macro_rules! impl_packing {
             }
 
             /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements.
-            #[inline(never)]
+            #[inline]
             fn unpack_single<const W: usize, const B: usize>(packed: &[Self; B], index: usize) -> Self
             {
-                paste! {
-                    [<unpack_single_ $T>]::<W, B>(packed, index)
+                const {
+                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                    assert!(B == 1024 * W / Self::T);
+                }
+
+                if W == 0 {
+                    return 0 as $T;
+                }
+
+                // Packing transposes each logical index into a FastLanes lane and row.
+                // Map the requested index back to those coordinates.
+                assert!(index < 1024, "Index must be less than 1024, got {}", index);
+                let (lane, row): (usize, usize) = {
+                    const LANES: [u8; 1024] = lanes_by_index::<$T>();
+                    const ROWS: [u8; 1024] = rows_by_index::<$T>();
+                    (LANES[index] as usize, ROWS[index] as usize)
+                };
+
+                if W == <$T>::T {
+                    return packed[<$T>::LANES * row + lane];
+                }
+
+                let mask: $T = (1 << (W % <$T>::T)) - 1;
+                let start_bit = row * W;
+                let start_word = start_bit / <$T>::T;
+                let lo_shift = start_bit % <$T>::T;
+                let remaining_bits = <$T>::T - lo_shift;
+
+                let lo = packed[<$T>::LANES * start_word + lane] >> lo_shift;
+                if remaining_bits >= W {
+                    lo & mask
+                } else {
+                    let hi = packed[<$T>::LANES * (start_word + 1) + lane] << remaining_bits;
+                    (lo | hi) & mask
                 }
             }
 
+            #[inline]
             unsafe fn unchecked_unpack_single(width: usize, packed: &[Self], index: usize) -> Self {
                 const T: usize = <$T>::T;
 
@@ -253,7 +242,7 @@ macro_rules! impl_packing {
                     match width {
                         #(W => {
                             const B: usize = 1024 * W / T;
-                            return [<unpack_single_ $T>]::<W, B>(
+                            return <$T>::unpack_single::<W, B>(
                                 unsafe { crate::as_array_unchecked(packed) },
                                 index,
                             );
@@ -262,7 +251,7 @@ macro_rules! impl_packing {
                         T => {
                             const W: usize = T;
                             const B: usize = 1024;
-                            return [<unpack_single_ $T>]::<W, B>(
+                            return <$T>::unpack_single::<W, B>(
                                 unsafe { crate::as_array_unchecked(packed) },
                                 index,
                             );
@@ -290,9 +279,7 @@ macro_rules! impl_packing {
                     return;
                 }
                 for (&index, value) in indices.iter().zip(output) {
-                    paste! {
-                        value.write([<unpack_single_ $T>]::<W, B>(packed, index));
-                    }
+                    value.write(<$T>::unpack_single::<W, B>(packed, index));
                 }
             }
 

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -60,7 +60,8 @@ pub trait BitPacking: FastLanes {
     ///
     /// # Panics
     ///
-    /// Panics if the output length differs from the index length or an index is not less than 1024.
+    /// Panics if the output length differs from the index length or, when `W` is not zero, an index
+    /// is not less than 1024.
     fn unpack_indices<const W: usize, const B: usize>(
         packed: &[Self; B],
         indices: &[usize],
@@ -81,7 +82,8 @@ pub trait BitPacking: FastLanes {
     ///
     /// # Panics
     ///
-    /// Panics if the output length differs from the index length or an index is not less than 1024.
+    /// Panics if the output length differs from the index length or, when `width` is not zero, an
+    /// index is not less than 1024.
     unsafe fn unchecked_unpack_indices(
         width: usize,
         input: &[Self],
@@ -276,9 +278,10 @@ macro_rules! impl_packing {
 
                 assert_eq!(indices.len(), output.len(), "Output length must equal index length");
                 if W == 0 {
-                    for (&index, value) in indices.iter().zip(output) {
+                    for value in output {
                         value.write(0 as Self);
                     }
+                    return;
                 }
                 for (&index, value) in indices.iter().zip(output) {
                     value.write(Self::unpack_single::<W, B>(packed, index));
@@ -457,12 +460,16 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Index must be less than 1024")]
-    fn test_unchecked_unpack_indices_rejects_invalid_index_at_zero_width() {
+    fn test_unpack_indices_zero_width_ignores_indices() {
+        let indices = [usize::MAX];
         let mut output = [MaybeUninit::<u32>::uninit()];
-        // SAFETY: the zero-width packed representation contains no elements. The invalid index is
-        // a documented panic condition, not a safety requirement.
-        unsafe { BitPacking::unchecked_unpack_indices(0, &[], &[1024], &mut output) };
+        BitPacking::unpack_indices::<0, 0>(&[], &indices, &mut output);
+        assert_eq!(assume_initialized(&output), [0]);
+
+        let mut output = [MaybeUninit::<u32>::uninit()];
+        // SAFETY: the zero-width packed representation contains no elements.
+        unsafe { BitPacking::unchecked_unpack_indices(0, &[], &indices, &mut output) };
+        assert_eq!(assume_initialized(&output), [0]);
     }
 
     fn assert_bitpack_roundtrip<T>(tc: &TestCase)

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -276,10 +276,9 @@ macro_rules! impl_packing {
 
                 assert_eq!(indices.len(), output.len(), "Output length must equal index length");
                 if W == 0 {
-                    assert!(
-                        indices.iter().all(|&index| index < 1024),
-                        "Index must be less than 1024"
-                    );
+                    for (&index, value) in indices.iter().zip(output) {
+                        value.write(0 as Self);
+                    }
                 }
                 for (&index, value) in indices.iter().zip(output) {
                     value.write(Self::unpack_single::<W, B>(packed, index));
@@ -293,11 +292,12 @@ macro_rules! impl_packing {
                 output: &mut [MaybeUninit<Self>],
             ) {
                 const T: usize = <$T>::T;
-
-                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
-                debug_assert_eq!(indices.len(), output.len(), "Output length must equal index length");
-                let packed_len = 128 * width / size_of::<Self>();
-                debug_assert_eq!(packed.len(), packed_len, "Input buffer must be of size {}", packed_len);
+                debug_assert!(width <= T, "Width must be less than or equal to {}", T);
+                #[cfg(debug_assertions)]
+                {
+                    let packed_len = 128 * width / size_of::<Self>();
+                    debug_assert_eq!(packed.len(), packed_len, "Input buffer must be of size {}", packed_len);
+                }
 
                 paste!(seq_t!(W in $T {
                     match width {

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -253,13 +253,19 @@ macro_rules! impl_packing {
                     match width {
                         #(W => {
                             const B: usize = 1024 * W / T;
-                            return <$T>::unpack_single::<W, B>(unsafe { crate::as_array_unchecked(packed) }, index);
+                            return [<unpack_single_ $T>]::<W, B>(
+                                unsafe { crate::as_array_unchecked(packed) },
+                                index,
+                            );
                         },)*
                         // seq_t has exclusive upper bound
                         T => {
                             const W: usize = T;
                             const B: usize = 1024;
-                            return <$T>::unpack_single::<W, B>(unsafe { crate::as_array_unchecked(packed) }, index);
+                            return [<unpack_single_ $T>]::<W, B>(
+                                unsafe { crate::as_array_unchecked(packed) },
+                                index,
+                            );
                         },
                         _ => unreachable!("Unsupported width: {}", width)
                     }

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -73,14 +73,15 @@ pub trait BitPacking: FastLanes {
     ///
     /// # Safety
     ///
-    /// The input slice must contain exactly `1024 * W / T` elements, where `T` is the unpacked bit
-    /// width of `Self` and `W` is `width`.
+    /// - The input slice must contain exactly `1024 * W / T` elements, where `T` is the unpacked bit
+    ///   width of `Self` and `W` is `width`.
+    /// - The `width` must be less than or equal to the unpacked bit width of `Self`.
+    ///
+    /// These conditions are checked only with `debug_assert`.
     ///
     /// # Panics
     ///
-    /// Panics if `width` exceeds the bit width of `Self`, the output length differs from the index
-    /// length, or an index is not less than 1024. Debug builds also panic unless the input length
-    /// equals `1024 * W / T`.
+    /// Panics if the output length differs from the index length or an index is not less than 1024.
     unsafe fn unchecked_unpack_indices(
         width: usize,
         input: &[Self],
@@ -428,18 +429,8 @@ mod test {
     }
 
     #[test]
-    fn test_unpack_indices_single() {
-        assert_u32_unpack_indices(&[731]);
-    }
-
-    #[test]
-    fn test_unpack_indices_duplicates() {
-        assert_u32_unpack_indices(&[17, 17, 511, 17, 511]);
-    }
-
-    #[test]
-    fn test_unpack_indices_unordered() {
-        assert_u32_unpack_indices(&[1023, 0, 700, 17, 512, 511, 1]);
+    fn test_unpack_indices_preserves_order_and_duplicates() {
+        assert_u32_unpack_indices(&[1023, 0, 17, 17, 511, 17, 511]);
     }
 
     #[test]
@@ -472,13 +463,6 @@ mod test {
         // SAFETY: the zero-width packed representation contains no elements. The invalid index is
         // a documented panic condition, not a safety requirement.
         unsafe { BitPacking::unchecked_unpack_indices(0, &[], &[1024], &mut output) };
-    }
-
-    #[test]
-    #[should_panic(expected = "Width must be less than or equal to 32")]
-    fn test_unchecked_unpack_indices_rejects_invalid_width() {
-        // SAFETY: an invalid width is a documented panic condition, not a safety requirement.
-        unsafe { u32::unchecked_unpack_indices(33, &[], &[], &mut []) };
     }
 
     fn assert_bitpack_roundtrip<T>(tc: &TestCase)

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -94,6 +94,50 @@ pub trait BitPacking: FastLanes {
 
 macro_rules! impl_packing {
     ($T:ty) => {
+        paste! {
+            #[inline(always)]
+            fn [<unpack_single_ $T>]<const W: usize, const B: usize>(
+                packed: &[$T; B],
+                index: usize,
+            ) -> $T {
+                const {
+                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
+                    assert!(B == 1024 * W / <$T>::T);
+                }
+
+                if W == 0 {
+                    return 0 as $T;
+                }
+
+                // Packing transposes each logical index into a FastLanes lane and row.
+                // Map the requested index back to those coordinates.
+                assert!(index < 1024, "Index must be less than 1024, got {}", index);
+                let (lane, row): (usize, usize) = {
+                    const LANES: [u8; 1024] = lanes_by_index::<$T>();
+                    const ROWS: [u8; 1024] = rows_by_index::<$T>();
+                    (LANES[index] as usize, ROWS[index] as usize)
+                };
+
+                if W == <$T>::T {
+                    return packed[<$T>::LANES * row + lane];
+                }
+
+                let mask: $T = (1 << (W % <$T>::T)) - 1;
+                let start_bit = row * W;
+                let start_word = start_bit / <$T>::T;
+                let lo_shift = start_bit % <$T>::T;
+                let remaining_bits = <$T>::T - lo_shift;
+
+                let lo = packed[<$T>::LANES * start_word + lane] >> lo_shift;
+                if remaining_bits >= W {
+                    lo & mask
+                } else {
+                    let hi = packed[<$T>::LANES * (start_word + 1) + lane] << remaining_bits;
+                    (lo | hi) & mask
+                }
+            }
+        }
+
         impl BitPacking for $T {
             #[inline(never)]
             fn pack<const W: usize, const B: usize>(
@@ -190,56 +234,12 @@ macro_rules! impl_packing {
             }
 
             /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements.
+            #[inline(never)]
             fn unpack_single<const W: usize, const B: usize>(packed: &[Self; B], index: usize) -> Self
             {
-                const {
-                    assert!(supported_bit_width(W, 8 * core::mem::size_of::<$T>()));
-                    assert!(B == 1024 * W / Self::T);
+                paste! {
+                    [<unpack_single_ $T>]::<W, B>(packed, index)
                 }
-
-                if W == 0 {
-                    // Special case for W=0, we just need to zero the output.
-                    return 0 as $T;
-                }
-
-                // We can think of the input array as effectively a row-major, left-to-right
-                // 2-D array of with `Self::LANES` columns and `Self::T` rows.
-                //
-                // Meanwhile, we can think of the packed array as either:
-                //      1. `Self::T` rows of W-bit elements, with `Self::LANES` columns
-                //      2. `W` rows of `Self::T`-bit words, with `Self::LANES` columns
-                //
-                // Bitpacking involves a transposition of the input array ordering, such that
-                // decompression can be fused efficiently with encodings like delta and RLE.
-                //
-                // First step, we need to get the lane and row for interpretation #1 above.
-                assert!(index < 1024, "Index must be less than 1024, got {}", index);
-                let (lane, row): (usize, usize) = {
-                    const LANES: [u8; 1024] = lanes_by_index::<$T>();
-                    const ROWS: [u8; 1024] = rows_by_index::<$T>();
-                    (LANES[index] as usize, ROWS[index] as usize)
-                };
-
-                if W == <$T>::T {
-                    // Special case for W==T, we can just read the value directly
-                    return packed[<$T>::LANES * row + lane];
-                }
-
-                let mask: $T = (1 << (W % <$T>::T)) - 1;
-                let start_bit = row * W;
-                let start_word = start_bit / <$T>::T;
-                let lo_shift = start_bit % <$T>::T;
-                let remaining_bits = <$T>::T - lo_shift;
-
-                let lo = packed[<$T>::LANES * start_word + lane] >> lo_shift;
-                return if remaining_bits >= W {
-                    // in this case we will mask out all bits of hi word
-                    lo & mask
-                } else {
-                    // guaranteed that lo_shift > 0 and thus remaining_bits < T
-                    let hi = packed[<$T>::LANES * (start_word + 1) + lane] << remaining_bits;
-                    (lo | hi) & mask
-                };
             }
 
             unsafe fn unchecked_unpack_single(width: usize, packed: &[Self], index: usize) -> Self {
@@ -284,7 +284,9 @@ macro_rules! impl_packing {
                     return;
                 }
                 for (&index, value) in indices.iter().zip(output) {
-                    value.write(Self::unpack_single::<W, B>(packed, index));
+                    paste! {
+                        value.write([<unpack_single_ $T>]::<W, B>(packed, index));
+                    }
                 }
             }
 

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -42,10 +42,6 @@ pub trait BitPacking: FastLanes {
     unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]);
 
     /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `index` is not less than 1024.
     fn unpack_single<const W: usize, const B: usize>(packed: &[Self; B], index: usize) -> Self;
 
     /// Unpacks selected elements from a packed array of 1024 `W` bit elements.
@@ -64,13 +60,11 @@ pub trait BitPacking: FastLanes {
     ///
     /// # Safety
     ///
-    /// The input slice must contain at least `1024 * W / T` elements, where `T` is the unpacked
-    /// bit width of `Self` and `W` is `width`.
+    /// - The input slice must be of length `1024 * W / T`, where `T` is the (unpacked) bit-width
+    ///   of `Self` and `W` is the packed bit-width.
+    /// - The `width` must be less than or equal to the (unpacked) bit-width of `Self`.
     ///
-    /// # Panics
-    ///
-    /// Panics if `width` exceeds the bit width of `Self` or `index` is not less than 1024. Debug
-    /// builds also panic unless the input length equals `1024 * W / T`.
+    /// These lengths are checked only with `debug_assert` (i.e., not checked on release builds).
     unsafe fn unchecked_unpack_single(width: usize, input: &[Self], index: usize) -> Self;
 
     /// Unpacks selected elements where `W` is known only at runtime.
@@ -79,8 +73,8 @@ pub trait BitPacking: FastLanes {
     ///
     /// # Safety
     ///
-    /// The input slice must contain at least `1024 * W / T` elements, where `T` is the unpacked
-    /// bit width of `Self` and `W` is `width`.
+    /// The input slice must contain exactly `1024 * W / T` elements, where `T` is the unpacked bit
+    /// width of `Self` and `W` is `width`.
     ///
     /// # Panics
     ///
@@ -201,8 +195,6 @@ macro_rules! impl_packing {
                     assert!(B == 1024 * W / Self::T);
                 }
 
-                assert!(index < 1024, "Index must be less than 1024, got {}", index);
-
                 if W == 0 {
                     // Special case for W=0, we just need to zero the output.
                     return 0 as $T;
@@ -219,6 +211,7 @@ macro_rules! impl_packing {
                 // decompression can be fused efficiently with encodings like delta and RLE.
                 //
                 // First step, we need to get the lane and row for interpretation #1 above.
+                assert!(index < 1024, "Index must be less than 1024, got {}", index);
                 let (lane, row): (usize, usize) = {
                     const LANES: [u8; 1024] = lanes_by_index::<$T>();
                     const ROWS: [u8; 1024] = rows_by_index::<$T>();
@@ -258,6 +251,12 @@ macro_rules! impl_packing {
                 }
 
                 assert_eq!(indices.len(), output.len(), "Output length must equal index length");
+                if W == 0 {
+                    assert!(
+                        indices.iter().all(|&index| index < 1024),
+                        "Index must be less than 1024"
+                    );
+                }
                 for (&index, value) in indices.iter().zip(output) {
                     value.write(Self::unpack_single::<W, B>(packed, index));
                 }
@@ -266,10 +265,9 @@ macro_rules! impl_packing {
             unsafe fn unchecked_unpack_single(width: usize, packed: &[Self], index: usize) -> Self {
                 const T: usize = <$T>::T;
 
-                assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
-                assert!(index < 1024, "Index must be less than 1024, got {}", index);
                 let packed_len = 128 * width / size_of::<Self>();
                 debug_assert_eq!(packed.len(), packed_len, "Input buffer must be of size {}", packed_len);
+                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
 
                 paste!(seq_t!(W in $T {
                     match width {
@@ -466,20 +464,6 @@ mod test {
         // SAFETY: the packed input has the required length. The mismatched output is a documented
         // panic condition, not a safety requirement.
         unsafe { BitPacking::unchecked_unpack_indices(1, &packed, &[], &mut output) };
-    }
-
-    #[test]
-    #[should_panic(expected = "Index must be less than 1024")]
-    fn test_unpack_single_rejects_invalid_index_at_zero_width() {
-        u32::unpack_single::<0, 0>(&[], 1024);
-    }
-
-    #[test]
-    #[should_panic(expected = "Index must be less than 1024")]
-    fn test_unchecked_unpack_single_rejects_invalid_index_at_zero_width() {
-        // SAFETY: the zero-width packed representation contains no elements. The invalid index is
-        // a documented panic condition, not a safety requirement.
-        unsafe { u32::unchecked_unpack_single(0, &[], 1024) };
     }
 
     #[test]

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -1,4 +1,5 @@
 use const_for::const_for;
+use core::mem::MaybeUninit;
 use core::mem::size_of;
 use pastey::paste;
 
@@ -41,19 +42,81 @@ pub trait BitPacking: FastLanes {
     unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]);
 
     /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is not less than 1024.
     fn unpack_single<const W: usize, const B: usize>(packed: &[Self; B], index: usize) -> Self;
+
+    /// Unpacks selected elements from a packed array of 1024 `W` bit elements.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the output length differs from the index length or an index is not less than 1024.
+    fn unpack_indices<const W: usize, const B: usize>(
+        packed: &[Self; B],
+        indices: &[usize],
+        output: &mut [MaybeUninit<Self>],
+    ) {
+        assert_eq!(
+            indices.len(),
+            output.len(),
+            "Output length must equal index length"
+        );
+        for (&index, value) in indices.iter().zip(output) {
+            value.write(Self::unpack_single::<W, B>(packed, index));
+        }
+    }
 
     /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements,
     /// where `W` is runtime-known instead of compile-time known.
     ///
     /// # Safety
     ///
-    /// - The input slice must be of length `1024 * W / T`, where `T` is the (unpacked) bit-width
-    ///   of `Self` and `W` is the packed bit-width.
-    /// - The `width` must be less than or equal to the (unpacked) bit-width of `Self`.
+    /// The input slice must contain at least `1024 * W / T` elements, where `T` is the unpacked
+    /// bit width of `Self` and `W` is `width`.
     ///
-    /// These lengths are checked only with `debug_assert` (i.e., not checked on release builds).
+    /// # Panics
+    ///
+    /// Panics if `width` exceeds the bit width of `Self` or `index` is not less than 1024. Debug
+    /// builds also panic unless the input length equals `1024 * W / T`.
     unsafe fn unchecked_unpack_single(width: usize, input: &[Self], index: usize) -> Self;
+
+    /// Unpacks selected elements where `W` is known only at runtime.
+    ///
+    /// This method dispatches on `width` once for the complete index batch.
+    ///
+    /// # Safety
+    ///
+    /// The input slice must contain at least `1024 * W / T` elements, where `T` is the unpacked
+    /// bit width of `Self` and `W` is `width`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `width` exceeds the bit width of `Self`, the output length differs from the index
+    /// length, or an index is not less than 1024. Debug builds also panic unless the input length
+    /// equals `1024 * W / T`.
+    unsafe fn unchecked_unpack_indices(
+        width: usize,
+        input: &[Self],
+        indices: &[usize],
+        output: &mut [MaybeUninit<Self>],
+    ) {
+        assert!(
+            width <= Self::T,
+            "Width must be less than or equal to {}",
+            Self::T
+        );
+        assert_eq!(
+            indices.len(),
+            output.len(),
+            "Output length must equal index length"
+        );
+        for (&index, value) in indices.iter().zip(output) {
+            // SAFETY: the caller guarantees that `input` contains the packed representation.
+            value.write(unsafe { Self::unchecked_unpack_single(width, input, index) });
+        }
+    }
 }
 
 macro_rules! impl_packing {
@@ -162,6 +225,8 @@ macro_rules! impl_packing {
                     assert!(B == 1024 * W / Self::T);
                 }
 
+                assert!(index < 1024, "Index must be less than 1024, got {}", index);
+
                 if W == 0 {
                     // Special case for W=0, we just need to zero the output.
                     return 0 as $T;
@@ -178,7 +243,6 @@ macro_rules! impl_packing {
                 // decompression can be fused efficiently with encodings like delta and RLE.
                 //
                 // First step, we need to get the lane and row for interpretation #1 above.
-                assert!(index < 1024, "Index must be less than 1024, got {}", index);
                 let (lane, row): (usize, usize) = {
                     const LANES: [u8; 1024] = lanes_by_index::<$T>();
                     const ROWS: [u8; 1024] = rows_by_index::<$T>();
@@ -210,9 +274,10 @@ macro_rules! impl_packing {
             unsafe fn unchecked_unpack_single(width: usize, packed: &[Self], index: usize) -> Self {
                 const T: usize = <$T>::T;
 
+                assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+                assert!(index < 1024, "Index must be less than 1024, got {}", index);
                 let packed_len = 128 * width / size_of::<Self>();
                 debug_assert_eq!(packed.len(), packed_len, "Input buffer must be of size {}", packed_len);
-                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
 
                 paste!(seq_t!(W in $T {
                     match width {
@@ -225,6 +290,43 @@ macro_rules! impl_packing {
                             const W: usize = T;
                             const B: usize = 1024;
                             return <$T>::unpack_single::<W, B>(unsafe { crate::as_array_unchecked(packed) }, index);
+                        },
+                        _ => unreachable!("Unsupported width: {}", width)
+                    }
+                }))
+            }
+
+            unsafe fn unchecked_unpack_indices(
+                width: usize,
+                packed: &[Self],
+                indices: &[usize],
+                output: &mut [MaybeUninit<Self>],
+            ) {
+                const T: usize = <$T>::T;
+
+                assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+                assert_eq!(indices.len(), output.len(), "Output length must equal index length");
+                let packed_len = 128 * width / size_of::<Self>();
+                debug_assert_eq!(packed.len(), packed_len, "Input buffer must be of size {}", packed_len);
+
+                paste!(seq_t!(W in $T {
+                    match width {
+                        #(W => {
+                            const B: usize = 1024 * W / T;
+                            return <$T>::unpack_indices::<W, B>(
+                                unsafe { crate::as_array_unchecked(packed) },
+                                indices,
+                                output,
+                            );
+                        },)*
+                        T => {
+                            const W: usize = T;
+                            const B: usize = 1024;
+                            return <$T>::unpack_indices::<W, B>(
+                                unsafe { crate::as_array_unchecked(packed) },
+                                indices,
+                                output,
+                            );
                         },
                         _ => unreachable!("Unsupported width: {}", width)
                     }
@@ -294,6 +396,114 @@ mod test {
                 values[i]
             );
         }
+    }
+
+    fn assume_initialized<T: Copy>(output: &[MaybeUninit<T>]) -> Vec<T> {
+        output
+            .iter()
+            .map(|value| {
+                // SAFETY: callers use this helper only after an unpack method initializes every
+                // output element.
+                unsafe { value.assume_init() }
+            })
+            .collect()
+    }
+
+    fn assert_u32_unpack_indices(indices: &[usize]) {
+        const WIDTH: usize = 13;
+        const PACKED_LENGTH: usize = 1024 * WIDTH / u32::T;
+
+        let values = array::from_fn(|index| ((index as u32).wrapping_mul(17)) & 0x1fff);
+        let mut packed = [0; PACKED_LENGTH];
+        BitPacking::pack::<WIDTH, PACKED_LENGTH>(&values, &mut packed);
+        let expected = indices
+            .iter()
+            .map(|&index| values[index])
+            .collect::<Vec<_>>();
+
+        let mut output = vec![MaybeUninit::uninit(); indices.len()];
+        BitPacking::unpack_indices::<WIDTH, PACKED_LENGTH>(&packed, indices, &mut output);
+        assert_eq!(assume_initialized(&output), expected);
+
+        let mut output = vec![MaybeUninit::uninit(); indices.len()];
+        // SAFETY: `packed` contains exactly one packed FastLanes block.
+        unsafe {
+            BitPacking::unchecked_unpack_indices(WIDTH, &packed, indices, &mut output);
+        }
+        assert_eq!(assume_initialized(&output), expected);
+    }
+
+    #[test]
+    fn test_unpack_indices_empty() {
+        assert_u32_unpack_indices(&[]);
+    }
+
+    #[test]
+    fn test_unpack_indices_single() {
+        assert_u32_unpack_indices(&[731]);
+    }
+
+    #[test]
+    fn test_unpack_indices_duplicates() {
+        assert_u32_unpack_indices(&[17, 17, 511, 17, 511]);
+    }
+
+    #[test]
+    fn test_unpack_indices_unordered() {
+        assert_u32_unpack_indices(&[1023, 0, 700, 17, 512, 511, 1]);
+    }
+
+    #[test]
+    fn test_unpack_indices_full_block() {
+        assert_u32_unpack_indices(&(0..1024).collect::<Vec<_>>());
+    }
+
+    #[test]
+    #[should_panic(expected = "Output length must equal index length")]
+    fn test_unpack_indices_rejects_output_length_mismatch() {
+        let packed = [0_u32; 32];
+        let mut output = [MaybeUninit::uninit(); 1];
+        BitPacking::unpack_indices::<1, 32>(&packed, &[], &mut output);
+    }
+
+    #[test]
+    #[should_panic(expected = "Output length must equal index length")]
+    fn test_unchecked_unpack_indices_rejects_output_length_mismatch() {
+        let packed = [0_u32; 32];
+        let mut output = [MaybeUninit::uninit(); 1];
+        // SAFETY: the packed input has the required length. The mismatched output is a documented
+        // panic condition, not a safety requirement.
+        unsafe { BitPacking::unchecked_unpack_indices(1, &packed, &[], &mut output) };
+    }
+
+    #[test]
+    #[should_panic(expected = "Index must be less than 1024")]
+    fn test_unpack_single_rejects_invalid_index_at_zero_width() {
+        u32::unpack_single::<0, 0>(&[], 1024);
+    }
+
+    #[test]
+    #[should_panic(expected = "Index must be less than 1024")]
+    fn test_unchecked_unpack_single_rejects_invalid_index_at_zero_width() {
+        // SAFETY: the zero-width packed representation contains no elements. The invalid index is
+        // a documented panic condition, not a safety requirement.
+        unsafe { u32::unchecked_unpack_single(0, &[], 1024) };
+    }
+
+    #[test]
+    #[should_panic(expected = "Index must be less than 1024")]
+    fn test_unchecked_unpack_indices_rejects_invalid_index_at_zero_width() {
+        let mut output = [MaybeUninit::<u32>::uninit()];
+        // SAFETY: the zero-width packed representation contains no elements. The invalid index is
+        // a documented panic condition, not a safety requirement.
+        unsafe { BitPacking::unchecked_unpack_indices(0, &[], &[1024], &mut output) };
+    }
+
+    #[test]
+    #[should_panic(expected = "Width must be less than or equal to 32")]
+    fn test_unchecked_unpack_indices_rejects_invalid_width() {
+        // SAFETY: an invalid width is a documented panic condition, not a safety requirement.
+        unsafe { u32::unchecked_unpack_indices(33, &[], &[], &mut []) };
     }
 
     fn assert_bitpack_roundtrip<T>(tc: &TestCase)
@@ -393,6 +603,51 @@ mod test {
         }
     }
 
+    fn assert_bitpack_unpack_indices_matches_bulk<T>(tc: &TestCase)
+    where
+        T: BitPacking + Debug + Integer + 'static,
+    {
+        let packed_source = tc.draw(
+            gs::vecs(gs::integers::<T>())
+                .min_size(BUFFER_SIZE)
+                .max_size(BUFFER_SIZE),
+        );
+        let indices = tc.draw(
+            gs::vecs(
+                gs::integers::<usize>()
+                    .min_value(0)
+                    .max_value(BUFFER_SIZE - 1),
+            )
+            .min_size(0)
+            .max_size(128),
+        );
+
+        for width in 0..=T::T {
+            let packed_length = (BUFFER_SIZE * width) / T::T;
+            let packed_input = &packed_source[..packed_length];
+            let mut unpacked = vec![T::zero(); BUFFER_SIZE];
+            // SAFETY: both buffers have the required lengths for `width`.
+            unsafe { T::unchecked_unpack(width, packed_input, &mut unpacked) };
+            let expected = indices
+                .iter()
+                .map(|&index| unpacked[index])
+                .collect::<Vec<_>>();
+            let mut output = vec![MaybeUninit::uninit(); indices.len()];
+
+            // SAFETY: `packed_input` contains exactly one packed FastLanes block.
+            unsafe {
+                T::unchecked_unpack_indices(width, packed_input, &indices, &mut output);
+            }
+
+            assert_eq!(
+                assume_initialized(&output),
+                expected,
+                "indexed unpack failed for type={} width={width} indices={indices:?}",
+                core::any::type_name::<T>(),
+            );
+        }
+    }
+
     fn reference_pack<T>(width: usize, input: &[T]) -> Vec<T>
     where
         T: BitPacking,
@@ -454,5 +709,6 @@ mod test {
     bitpack_property_tests!(bitpack_roundtrip, 10 for u8, u16, u32, u64);
     bitpack_property_tests!(bitpack_repack_roundtrip, 10 for u8, u16, u32, u64);
     bitpack_property_tests!(bitpack_unpack_single_matches_bulk, 10 for u8, u16, u32, u64);
+    bitpack_property_tests!(bitpack_unpack_indices_matches_bulk, 10 for u8, u16, u32, u64);
     bitpack_property_tests!(bitpack_matches_reference, 10 for u8, u16, u32, u64);
 }


### PR DESCRIPTION
Add `unpack_indices` and `unchecked_unpack_indices` to extract selected values without a complete 1,024-value unpack.

Use `unpack_indices` when the bit width and packed length are compile-time constants. Use `unchecked_unpack_indices` when the bit width is available only at runtime. It dispatches the runtime width once per batch.

Both methods write into `MaybeUninit` output. Use `unpack_single` for one selected value. Use full unpack above the recommended threshold.

One private `#[inline(always)]` helper implements single-value extraction. Public `unpack_single` keeps an out-of-line boundary. The runtime dispatcher and batch path inline the helper after width dispatch. This keeps width-specific expansion inside library code.

## Performance

Native Apple M1 benchmarks use Rust 1.91.0 and `-C target-cpu=native`.

At 8 and 32 selected values, batch extraction is 2.0–3.4× faster than repeated `unpack_single` calls.

The table gives a conservative dispatch policy across the sampled packed widths.

| Physical type | Use batch when | Use full unpack when |
| --- | ---: | ---: |
| `u8` | `n <= 16` | `n > 16` |
| `u16` | `n <= 32` | `n > 32` |
| `u32` | `n <= 64` | `n > 64` |
| `u64` | `n <= 160` | `n > 160` |

The grid covers widths 1, 4, and 7 for `u8`. It covers widths 1, 3, 8, and 15 for `u16`.

It covers widths 1, 8, 16, 24, and 31 for `u32`. It covers widths 1, 16, 32, 48, and 63 for `u64`.

The limiting measured crossovers were 18–19, 32–34, 68–72, and 176–184. The rounded thresholds leave margin for other hardware.

Packed-width effects were non-monotonic, so the policy uses only the physical type and selected-value count.

`cargo asm` confirms one runtime-width dispatch per batch. The generated `u16` batch function contains no per-index `unpack_single` calls.

## Code size

The release rlib grows from 3,750,536 bytes on `develop` to 3,942,416 bytes, a 5.1% increase. Object text grows from 419,814 bytes to 447,917 bytes, a 6.7% increase.

## Verification

Tests cover every integer type and runtime width. They also cover empty, duplicate, unordered, full-block, zero-width, and invalid inputs.

🤖 Generated with [Codex](https://openai.com/codex/)
