### PR TITLE
Assertions in functions are more optimisation friendly

### DIFF
--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -127,9 +127,10 @@ macro_rules! impl_packing {
             }
 
             unsafe fn unchecked_pack(width: usize, input: &[Self], output: &mut [Self]) {
-                // `width > Self::T` falls through to the `unreachable!` arm below in every build.
-                debug_assert!(input.len() == 1024);
-                debug_assert!(output.len() == 128 * width / size_of::<Self>());
+                let packed_len = 128 * width / size_of::<Self>();
+                debug_assert_eq!(output.len(), packed_len, "Output buffer must be of size 1024 * W / T");
+                debug_assert_eq!(input.len(), 1024, "Input buffer must be of size 1024");
+                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
 
                 paste!(seq_t!(W in $T {
                     match width {
@@ -174,9 +175,10 @@ macro_rules! impl_packing {
             }
 
             unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]) {
-                // `width > Self::T` falls through to the `unreachable!` arm below in every build.
-                debug_assert!(input.len() == 128 * width / size_of::<Self>());
-                debug_assert!(output.len() == 1024);
+                let packed_len = 128 * width / size_of::<Self>();
+                debug_assert_eq!(input.len(), packed_len, "Input buffer must be of size 1024 * W / T");
+                debug_assert_eq!(output.len(), 1024, "Output buffer must be of size 1024");
+                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
 
                 paste!(seq_t!(W in $T {
                     match width {
@@ -277,8 +279,9 @@ macro_rules! impl_packing {
             unsafe fn unchecked_unpack_single(width: usize, packed: &[Self], index: usize) -> Self {
                 const T: usize = <$T>::T;
 
-                // `width > T` falls through to the `unreachable!` arm below in every build.
-                debug_assert!(packed.len() == 128 * width / size_of::<Self>());
+                let packed_len = 128 * width / size_of::<Self>();
+                debug_assert_eq!(packed.len(), packed_len, "Input buffer must be of size {}", packed_len);
+                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
 
                 paste!(seq_t!(W in $T {
                     match width {
@@ -332,8 +335,12 @@ macro_rules! impl_packing {
                 output: &mut [MaybeUninit<Self>],
             ) {
                 const T: usize = <$T>::T;
-                // `width > T` falls through to the `unreachable!` arm below in every build.
-                debug_assert!(packed.len() == 128 * width / size_of::<Self>());
+                debug_assert!(width <= T, "Width must be less than or equal to {}", T);
+                #[cfg(debug_assertions)]
+                {
+                    let packed_len = 128 * width / size_of::<Self>();
+                    debug_assert_eq!(packed.len(), packed_len, "Input buffer must be of size {}", packed_len);
+                }
 
                 paste!(seq_t!(W in $T {
                     match width {

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -20,9 +20,12 @@ pub trait BitPacking: FastLanes {
     /// - The input slice must be of exactly length 1024.
     /// - The output slice must be of length `1024 * W / T`, where `T` is the (unpacked) bit-width
     ///   of `Self` and `W` is the packed bit-width.
-    /// - The `width` must be less than or equal to the (unpacked) bit-width of `Self`.
     ///
     /// These lengths are checked only with `debug_assert` (i.e., not checked on release builds).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `width` is greater than the (unpacked) bit-width of `Self`.
     unsafe fn unchecked_pack(width: usize, input: &[Self], output: &mut [Self]);
 
     /// Unpacks 1024 elements from `W` bits each.
@@ -36,12 +39,19 @@ pub trait BitPacking: FastLanes {
     /// - The input slice must be of length `1024 * W / T`, where `T` is the (unpacked) bit-width
     ///   of `Self` and `W` is the packed bit-width.
     /// - The output slice must be of exactly length 1024.
-    /// - The `width` must be less than or equal to the (unpacked) bit-width of `Self`.
     ///
     /// These lengths are checked only with `debug_assert` (i.e., not checked on release builds).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `width` is greater than the (unpacked) bit-width of `Self`.
     unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]);
 
     /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `W` is not zero and `index` is not less than 1024.
     fn unpack_single<const W: usize, const B: usize>(packed: &[Self; B], index: usize) -> Self;
 
     /// Unpacks a single element at the provided index from a packed array of 1024 `W` bit elements,
@@ -51,9 +61,13 @@ pub trait BitPacking: FastLanes {
     ///
     /// - The input slice must be of length `1024 * W / T`, where `T` is the (unpacked) bit-width
     ///   of `Self` and `W` is the packed bit-width.
-    /// - The `width` must be less than or equal to the (unpacked) bit-width of `Self`.
     ///
-    /// These lengths are checked only with `debug_assert` (i.e., not checked on release builds).
+    /// This length is checked only with `debug_assert` (i.e., not checked on release builds).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `width` is greater than the (unpacked) bit-width of `Self` or, when `width` is
+    /// not zero, `index` is not less than 1024.
     unsafe fn unchecked_unpack_single(width: usize, input: &[Self], index: usize) -> Self;
 
     /// Unpacks selected elements from a packed array of 1024 `W` bit elements.
@@ -76,14 +90,13 @@ pub trait BitPacking: FastLanes {
     ///
     /// - The input slice must contain exactly `1024 * W / T` elements, where `T` is the unpacked bit
     ///   width of `Self` and `W` is `width`.
-    /// - The `width` must be less than or equal to the unpacked bit width of `Self`.
     ///
-    /// These conditions are checked only with `debug_assert`.
+    /// This length is checked only with `debug_assert` (i.e., not checked on release builds).
     ///
     /// # Panics
     ///
-    /// Panics if the output length differs from the index length or, when `width` is not zero, an
-    /// index is not less than 1024.
+    /// Panics if `width` is greater than the unpacked bit width of `Self`, if the output length
+    /// differs from the index length or, when `width` is not zero, an index is not less than 1024.
     unsafe fn unchecked_unpack_indices(
         width: usize,
         input: &[Self],
@@ -114,10 +127,9 @@ macro_rules! impl_packing {
             }
 
             unsafe fn unchecked_pack(width: usize, input: &[Self], output: &mut [Self]) {
-                let packed_len = 128 * width / size_of::<Self>();
-                debug_assert_eq!(output.len(), packed_len, "Output buffer must be of size 1024 * W / T");
-                debug_assert_eq!(input.len(), 1024, "Input buffer must be of size 1024");
-                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+                // `width > Self::T` falls through to the `unreachable!` arm below in every build.
+                debug_assert!(input.len() == 1024);
+                debug_assert!(output.len() == 128 * width / size_of::<Self>());
 
                 paste!(seq_t!(W in $T {
                     match width {
@@ -162,10 +174,9 @@ macro_rules! impl_packing {
             }
 
             unsafe fn unchecked_unpack(width: usize, input: &[Self], output: &mut [Self]) {
-                let packed_len = 128 * width / size_of::<Self>();
-                debug_assert_eq!(input.len(), packed_len, "Input buffer must be of size 1024 * W / T");
-                debug_assert_eq!(output.len(), 1024, "Output buffer must be of size 1024");
-                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+                // `width > Self::T` falls through to the `unreachable!` arm below in every build.
+                debug_assert!(input.len() == 128 * width / size_of::<Self>());
+                debug_assert!(output.len() == 1024);
 
                 paste!(seq_t!(W in $T {
                     match width {
@@ -215,7 +226,8 @@ macro_rules! impl_packing {
                 // decompression can be fused efficiently with encodings like delta and RLE.
                 //
                 // First step, we need to get the lane and row for interpretation #1 above.
-                assert!(index < 1024, "Index must be less than 1024, got {}", index);
+                // Indexing the 1024-entry tables is the `index < 1024` bounds check; a separate
+                // assert would only add a second panic path that captures `index` for formatting.
                 let (lane, row): (usize, usize) = {
                     const LANES: [u8; 1024] = lanes_by_index::<$T>();
                     const ROWS: [u8; 1024] = rows_by_index::<$T>();
@@ -248,9 +260,8 @@ macro_rules! impl_packing {
             unsafe fn unchecked_unpack_single(width: usize, packed: &[Self], index: usize) -> Self {
                 const T: usize = <$T>::T;
 
-                let packed_len = 128 * width / size_of::<Self>();
-                debug_assert_eq!(packed.len(), packed_len, "Input buffer must be of size {}", packed_len);
-                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+                // `width > T` falls through to the `unreachable!` arm below in every build.
+                debug_assert!(packed.len() == 128 * width / size_of::<Self>());
 
                 paste!(seq_t!(W in $T {
                     match width {
@@ -285,7 +296,7 @@ macro_rules! impl_packing {
                     assert!(B == 1024 * W / Self::T);
                 }
 
-                assert_eq!(indices.len(), output.len(), "Output length must equal index length");
+                assert!(indices.len() == output.len(), "Output length must equal index length");
                 if W == 0 {
                     for value in output {
                         value.write(0 as Self);
@@ -304,12 +315,8 @@ macro_rules! impl_packing {
                 output: &mut [MaybeUninit<Self>],
             ) {
                 const T: usize = <$T>::T;
-                debug_assert!(width <= T, "Width must be less than or equal to {}", T);
-                #[cfg(debug_assertions)]
-                {
-                    let packed_len = 128 * width / size_of::<Self>();
-                    debug_assert_eq!(packed.len(), packed_len, "Input buffer must be of size {}", packed_len);
-                }
+                // `width > T` falls through to the `unreachable!` arm below in every build.
+                debug_assert!(packed.len() == 128 * width / size_of::<Self>());
 
                 paste!(seq_t!(W in $T {
                     match width {

--- a/src/bitpacking.rs
+++ b/src/bitpacking.rs
@@ -234,9 +234,17 @@ macro_rules! impl_packing {
                     (LANES[index] as usize, ROWS[index] as usize)
                 };
 
+                // The table lookups above bound `lane < LANES` and `row < T`, and the `const`
+                // block bounds `B == LANES * W`. Every `packed` read below is therefore in-bounds
+                // by construction, so it is `get_unchecked` rather than a checked index whose
+                // bounds LLVM cannot prove away through the table loads.
+
                 if W == <$T>::T {
-                    // Special case for W==T, we can just read the value directly
-                    return packed[<$T>::LANES * row + lane];
+                    // Special case for W==T, we can just read the value directly.
+                    // SAFETY: `LANES * row + lane <= LANES * (T - 1) + LANES - 1 = 1024 - 1 < B`.
+                    let word = <$T>::LANES * row + lane;
+                    debug_assert!(word < B);
+                    return unsafe { *packed.get_unchecked(word) };
                 }
 
                 let mask: $T = (1 << (W % <$T>::T)) - 1;
@@ -245,13 +253,22 @@ macro_rules! impl_packing {
                 let lo_shift = start_bit % <$T>::T;
                 let remaining_bits = <$T>::T - lo_shift;
 
-                let lo = packed[<$T>::LANES * start_word + lane] >> lo_shift;
+                // SAFETY: `start_word = row * W / T <= (T - 1) * W / T < W`, so
+                // `LANES * start_word + lane < LANES * W == B`.
+                let lo_word = <$T>::LANES * start_word + lane;
+                debug_assert!(lo_word < B);
+                let lo = unsafe { *packed.get_unchecked(lo_word) } >> lo_shift;
                 return if remaining_bits >= W {
                     // in this case we will mask out all bits of hi word
                     lo & mask
                 } else {
                     // guaranteed that lo_shift > 0 and thus remaining_bits < T
-                    let hi = packed[<$T>::LANES * (start_word + 1) + lane] << remaining_bits;
+                    // SAFETY: the element straddles `start_word` and `start_word + 1`, so its last
+                    // bit `row * W + W - 1 <= T * W - 1` lies in word `start_word + 1 <= W - 1`,
+                    // hence `LANES * (start_word + 1) + lane < LANES * W == B`.
+                    let hi_word = <$T>::LANES * (start_word + 1) + lane;
+                    debug_assert!(hi_word < B);
+                    let hi = unsafe { *packed.get_unchecked(hi_word) } << remaining_bits;
                     (lo | hi) & mask
                 };
             }

--- a/src/bitpacking_cmp.rs
+++ b/src/bitpacking_cmp.rs
@@ -40,6 +40,9 @@ pub trait BitPackingCompare: FastLanes {
     /// The input slice must be of length `1024 * W / T`, where `T` is the bit-width of Self and `W`
     /// is the packed width. The output is exactly `[u64; 16]` (`1024` bits).
     /// These lengths are checked only with `debug_assert` (i.e., not checked on release builds).
+    ///
+    /// # Panics
+    /// Panics if `width` is greater than the bit-width of `Self`.
     unsafe fn unchecked_unpack_cmp<V, F>(
         width: usize,
         input: &[Self],
@@ -111,9 +114,8 @@ macro_rules! impl_packing_compare {
                 V: FastLanesComparable<Bitpacked = Self>,
                 F: Fn(V, V) -> bool
             {
-                let packed_len = 128 * width / size_of::<Self>();
-                debug_assert_eq!(input.len(), packed_len, "Input buffer must be of size 1024 * W / T");
-                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+                // `width > Self::T` falls through to the `unreachable!` arm below in every build.
+                debug_assert!(input.len() == 128 * width / size_of::<Self>());
 
                 paste!(seq_t!(W in $T {
                     match width {

--- a/src/bitpacking_cmp.rs
+++ b/src/bitpacking_cmp.rs
@@ -114,8 +114,9 @@ macro_rules! impl_packing_compare {
                 V: FastLanesComparable<Bitpacked = Self>,
                 F: Fn(V, V) -> bool
             {
-                // `width > Self::T` falls through to the `unreachable!` arm below in every build.
-                debug_assert!(input.len() == 128 * width / size_of::<Self>());
+                let packed_len = 128 * width / size_of::<Self>();
+                debug_assert_eq!(input.len(), packed_len, "Input buffer must be of size 1024 * W / T");
+                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
 
                 paste!(seq_t!(W in $T {
                     match width {

--- a/src/ffor.rs
+++ b/src/ffor.rs
@@ -22,6 +22,9 @@ pub trait FoR: BitPacking {
     /// The input slice must be of length `1024 * W / T`, where `T` is the bit-width of Self and `W`
     /// is the packed width. The output slice must be of exactly length 1024.
     /// These lengths are checked only with `debug_assert` (i.e., not checked on release builds).
+    ///
+    /// # Panics
+    /// Panics if `width` is greater than the bit-width of `Self`.
     unsafe fn unchecked_unfor_pack(
         width: usize,
         input: &[Self],
@@ -69,10 +72,9 @@ macro_rules! impl_for {
             }
 
            unsafe fn unchecked_unfor_pack(width: usize, input: &[Self], reference: Self, output: &mut [Self]) {
-                let packed_len = 128 * width / size_of::<Self>();
-                debug_assert_eq!(input.len(), packed_len, "Input buffer must be of size 1024 * W / T");
-                debug_assert_eq!(output.len(), 1024, "Output buffer must be of size 1024");
-                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
+                // `width > Self::T` falls through to the `unreachable!` arm below in every build.
+                debug_assert!(input.len() == 128 * width / size_of::<Self>());
+                debug_assert!(output.len() == 1024);
 
                 paste!(seq_t!(W in $T {
                     match width {

--- a/src/ffor.rs
+++ b/src/ffor.rs
@@ -72,9 +72,10 @@ macro_rules! impl_for {
             }
 
            unsafe fn unchecked_unfor_pack(width: usize, input: &[Self], reference: Self, output: &mut [Self]) {
-                // `width > Self::T` falls through to the `unreachable!` arm below in every build.
-                debug_assert!(input.len() == 128 * width / size_of::<Self>());
-                debug_assert!(output.len() == 1024);
+                let packed_len = 128 * width / size_of::<Self>();
+                debug_assert_eq!(input.len(), packed_len, "Input buffer must be of size 1024 * W / T");
+                debug_assert_eq!(output.len(), 1024, "Output buffer must be of size 1024");
+                debug_assert!(width <= Self::T, "Width must be less than or equal to {}", Self::T);
 
                 paste!(seq_t!(W in $T {
                     match width {


### PR DESCRIPTION
Most of the asserts in this codebase cause the compiler to capture arguments. We can get 99% of the assert functionality by removing the formatting from messages and letting the default message handle it.

While doing this I realised that our unpack_single bounds are not obvious to the compiler and it can't optimise away bounds check at the final value access. This is also fixed here to make these functions more optimisation friendly